### PR TITLE
[profilers] Added multi-threaded profiling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         "pylint",
         "mongomock",
         "requests",
+        "mtprof",
     ],
     entry_points={
         "console_scripts": [

--- a/uengine/base.py
+++ b/uengine/base.py
@@ -186,7 +186,7 @@ class Base:
                 flask.before_request(profilers.before_request)
                 flask.after_request(profilers.after_request)
             except ImportError:
-                ctx.log.error(
+                ctx.log.exception(
                     "error importing profiler, profiling will be disabled")
 
             # pylint: disable=unused-variable

--- a/uengine/profilers.py
+++ b/uengine/profilers.py
@@ -1,4 +1,5 @@
 import cProfile
+import mtprof
 import io
 import line_profiler
 import pstats
@@ -15,7 +16,10 @@ def before_request():
         if ctx.line_profiler.functions:
             g.line_profiler = line_profiler.LineProfiler(*ctx.line_profiler.functions)
             g.line_profiler.enable()
-        g.profiler = cProfile.Profile()
+        if get_boolean_request_param("profile_threads"):
+            g.profiler = mtprof.Profile()
+        else:
+            g.profiler = cProfile.Profile()
         g.profiler.enable()
 
 


### PR DESCRIPTION
`<url>?profile=1&profile_threads=1` injects the profiler into new threads. All threads that are started _and_ finished while the request is being processed are profiled. That means that unrelated threads that happened to spawn and complete within that time will be included in the profile. On the other hand, stray threads will be silently skipped.

Without `profile_threads` the behaviour is unchanged

Unrelated:
To make profiler import error more prominent the traceback is now printed